### PR TITLE
Default Claude init to skip permissions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,7 @@ fn parse_config(contents: &str) -> Option<HashMap<String, Vec<String>>> {
 fn builtin_command_args(name: &str) -> Vec<String> {
     match name {
         "codex" => vec!["--dangerously-bypass-approvals-and-sandbox".into()],
+        "claude" => vec!["--dangerously-skip-permissions".into()],
         _ => vec![],
     }
 }
@@ -300,7 +301,7 @@ fn default_config_contents() -> &'static str {
 args = ["--dangerously-bypass-approvals-and-sandbox"]
 
 [commands.claude]
-args = []
+args = ["--dangerously-skip-permissions"]
 "#
 }
 

--- a/tests/worktree.rs
+++ b/tests/worktree.rs
@@ -369,5 +369,6 @@ fn init_writes_default_config() -> TestResult {
     let contents = fs::read_to_string(config)?;
     assert!(contents.contains("codex"));
     assert!(contents.contains("--dangerously-bypass-approvals-and-sandbox"));
+    assert!(contents.contains("--dangerously-skip-permissions"));
     Ok(())
 }


### PR DESCRIPTION
## Summary
- default the claude tool to pass --dangerously-skip-permissions
- write the same flag into the generated config template
- cover the new default in the init config test

## Testing
- cargo test
